### PR TITLE
Correct error in Quick tutorial

### DIFF
--- a/docs/source/quick_tutorial.rst
+++ b/docs/source/quick_tutorial.rst
@@ -68,7 +68,7 @@ the documentation)
 .. code-block:: python
 
    # call this function to set the truncation number for each mode of the circuit. 
-   cr.set_trunc_nums([25, 1, 25])
+   cr.set_trunc_nums([25, 25])
 
 We get the first two eigenfrequencies of the circuit to calculate the qubit frequency via:
 


### PR DESCRIPTION
Copy-pasting the code in the "Quick tutorial" results in the following error:

```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[28], line 22
     19 # define the circuit
     20 cr = sq.Circuit(elements)
---> 22 cr.set_trunc_nums([25, 1, 25])
     24 # get the first two eigenfrequencies and eigenvectors
     25 efreqs, evecs = cr.diag(n_eig=2)

File [.../python3.12/site-packages/SQcircuit/circuit.py#line=1356), in Circuit.set_trunc_nums(self, nums)
   1355     raise ValueError('The input must be be a python list')
   1356 if len(nums) != self.n:
-> 1357     raise ValueError(
   1358         'The number of modes (length of the input) must be equal to the'
   1359         ' number of nodes.'
   1360     )
   1362 self.m = self.n*[1]
   1364 for i in range(self.n):
   1365     # for charge modes:

ValueError: The number of modes (length of the input) must be equal to the number of nodes.
```

I assume this can be solved by using `[25, 25]` instead of `[25, 1, 25]`.


I'm using SQcircuit 1.0.0 and qutip 5.0.3.